### PR TITLE
Allow unlimited concurrent connections

### DIFF
--- a/lib/eyeserver.js
+++ b/lib/eyeserver.js
@@ -1,3 +1,4 @@
+require("http").globalAgent.maxSockets = Infinity;
 var express = require('express'),
     Eye = require('./eye');
 


### PR DESCRIPTION
Previously, a maximum of 5 concurrent connections was allowed (default).
