### PR TITLE
Allow blank nodes in N3 data

### DIFF
--- a/lib/eye.js
+++ b/lib/eye.js
@@ -87,7 +87,7 @@ var eyePrototype = Eye.prototype = {
 
     function addDataItem(dataItem, modifier) {
       // does it contain a protocol name of some sort?
-      if (dataItem.match(/^\w+:/)) {
+      if (dataItem.match(/^[a-zA-Z0-9]+:/)) {
         // is it HTTP(S), but not on a reserved domain?
         if (dataItem.match(/^https?:\/\/(?!localhost|127\.0\.0\.1|[0:]*:1)/)) {
           // cache the resource and add it


### PR DESCRIPTION
The regular expression <code>/^\w+:/</code> used to check if the data contains a protocol name also selects blank nodes (e.g. <code>_:b0</code>).

To allow the use of blank nodes in N3 data, the underscore character should be removed from the regular expression selection: <code>/^[a-zA-Z0-9]+:/</code>.
