### PR TITLE
Make eyeserver work with new EYE versions

### DIFF
--- a/lib/eye.js
+++ b/lib/eye.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn,
 var commentRegex = /^#.*$\n/mg,
     localIdentifierRegex = /<\/tmp\/([^#]+)#([^>]+>)/g,
     prefixDeclarationRegex = /@prefix ([\w\-]*:) <([^>]+)>.\n/g,
-    eyeSignatureRegex = /^Id: euler\.yap/m,
+    eyeSignatureRegex = /^(Id: euler\.yap|EYE-)/m,
     errorRegex = /^\*\* ERROR \*\*\s*(.*)$/m;
 
 var noArgOptions = ['nope', 'noBranch', 'noDistinct', 'noQvars',


### PR DESCRIPTION
Changed the eyeSignatureRegex to accept new output.
Regex is backward compatible with older versions.