### PR TITLE
window OS error fixed

### DIFF
--- a/lib/eye.js
+++ b/lib/eye.js
@@ -148,7 +148,12 @@ var eyePrototype = Eye.prototype = {
         return;
 
       // start EYE
-      eye = (self.spawn || spawn)('eye', args);
+      if(/^win/.test(process.platform)){
+        eye = (self.spawn || spawn)('eye.cmd', args);
+      }else{
+        eye = (self.spawn || spawn)('eye', args);
+      }
+      
 
       // capture stdout
       var output = "";


### PR DESCRIPTION
window OS needs `eye.cmd`, not `eye`

So I added this code.