### PR TITLE
Fix eyeserver init

### DIFF
--- a/lib/eye.js
+++ b/lib/eye.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn,
 var commentRegex = /^#.*$\n/mg,
     localIdentifierRegex = /<\/tmp\/([^#]+)#([^>]+>)/g,
     prefixDeclarationRegex = /^@prefix|PREFIX ([\w\-]*:) <([^>]+)>\.?\n/g,
-    eyeSignatureRegex = /^(Id: euler\.yap|EYE-)/m,
+    eyeSignatureRegex = /^(Id: euler\.yap|EYE)/m,
     errorRegex = /^\*\* ERROR \*\*\s*(.*)$/m;
 
 var noArgOptions = ['nope', 'noBranch', 'noDistinct', 'noQvars',


### PR DESCRIPTION
Issue #13 was caused by a change in the EYE signature. This fixes #13
If a new release is made, this will also end up in the eyeserver docker image.