### PR TITLE
Allow 'traditional' arg for old @prefix notation

### DIFF
--- a/lib/eye.js
+++ b/lib/eye.js
@@ -12,7 +12,7 @@ var noArgOptions = ['nope', 'noBranch', 'noDistinct', 'noQvars',
                     'noQnames', 'quiet', 'quickFalse', 'quickPossible',
                     'quickAnswer', 'think', 'ances', 'ignoreSyntaxError',
                     'pcl', 'strings', 'debug', 'profile', 'version', 'help',
-                    'pass', 'passAll'];
+                    'pass', 'passAll', 'traditional'];
 
 // An Eye object provides reasoning methods.
 function Eye(options) {


### PR DESCRIPTION
EyeServer filters out the `traditional` argument for old PREFIX notation.
I think it should be allowed.