### PR TITLE
Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ eyeserver 8000
 ### Using
 
 ``` bash
-$ curl "http://localhost:8000/?data=http://eulersharp.sourceforge.net/2003/03swap/socrates.n3&query=http://eulersharp.sourceforge.net/2003/03swap/socratesF.n3"
+$ curl "http://localhost:8000/?data=https://n3.restdesc.org/n3/friends.n3&data=https://n3.restdesc.org/n3/knows-rule.n3&query=https://n3.restdesc.org/n3/query-all.n3"
 ```
 
 ## Learn more.


### PR DESCRIPTION
sourceforge resources fails with a `301` response. Ideally redirects are followed once EyeServer gets refactored.
For now I've changed the example in the README to something that works.

```
❯ curl "http://localhost:8000/?data=http://eulersharp.sourceforge.net/2003/03swap/socrates.n3&query=http://eulersharp.sourceforge.net/2003/03swap/socratesF.n3"
GET request to http://eulersharp.sourceforge.net/2003/03swap/socratesF.n3 failed with status 301
❯ curl "http://localhost:8000/?data=https://n3.restdesc.org/n3/friends.n3&data=https://n3.restdesc.org/n3/knows-rule.n3&query=https://n3.restdesc.org/n3/query-all.n3"

@prefix ppl: <http://example.org/people#>.
@prefix foaf: <http://xmlns.com/foaf/0.1/>.

ppl:Cindy foaf:knows ppl:John.
ppl:Cindy foaf:knows ppl:Eliza.
ppl:Cindy foaf:knows ppl:Kate.
ppl:Eliza foaf:knows ppl:John.
ppl:Peter foaf:knows ppl:John.
ppl:John foaf:knows ppl:Cindy.
ppl:Eliza foaf:knows ppl:Cindy.
ppl:Kate foaf:knows ppl:Cindy.
ppl:John foaf:knows ppl:Eliza.
ppl:John foaf:knows ppl:Peter.
```